### PR TITLE
fix: correct sfdx command formatting in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to Salesforce (JWT)
 on:
   push:
     branches:
-      - master  # 실제 사용하는 브랜치 이름으로 변경 가능 (예: main)
+      - master # 실제 사용하는 브랜치 이름으로 변경 가능 (예: main)
 
 jobs:
   deploy:
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Salesforce CLI
-        uses: sfdx-actions/setup-sfdx@v1  # 공식 GitHub 액션 추천
+        uses: sfdx-actions/setup-sfdx@v1 # 공식 GitHub 액션 추천
 
       - name: Create server.key from Secret
         run: echo "${{ secrets.SF_JWT_KEY }}" > server.key
@@ -24,18 +24,18 @@ jobs:
 
       - name: Authenticate to Salesforce (JWT)
         run: |
-          sfdx force:auth:jwt:grant
-            --clientid "${{ secrets.SF_CONSUMER_KEY }}"
-            --jwtkeyfile server.key
-            --username "${{ secrets.SF_USERNAME }}"
-            --instanceurl https://login.salesforce.com
+          sfdx force:auth:jwt:grant \
+            --clientid "${{ secrets.SF_CONSUMER_KEY }}" \
+            --jwtkeyfile server.key \
+            --username "${{ secrets.SF_USERNAME }}" \
+            --instanceurl https://login.salesforce.com \
             --setdefaultusername
 
       - name: Deploy to Salesforce
         run: |
-          sfdx force:source:deploy
-            -p force-app
-            --testlevel RunLocalTests
+          sfdx force:source:deploy \
+            -p force-app \
+            --testlevel RunLocalTests \
             --json > deploy-result.json
 
       - name: Show Deployment Result (if failed)


### PR DESCRIPTION
## Summary
- ensure multi-line sfdx commands run as a single command in GitHub Actions

## Testing
- `npm test` *(fails: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_689447d17970833081b02d93e745a470