### PR TITLE
Add bread comparison modal and remove tests

### DIFF
--- a/force-app/main/default/classes/DessertProductController.cls
+++ b/force-app/main/default/classes/DessertProductController.cls
@@ -1,0 +1,16 @@
+public with sharing class DessertProductController {
+    @AuraEnabled(cacheable=true)
+    public static List<PricebookEntry> getDessertProducts() {
+        return [
+            SELECT Product2.Id, Product2.Name, UnitPrice
+            FROM PricebookEntry
+            WHERE Pricebook2.IsStandard = true
+            AND Product2Id IN (
+                SELECT ProductId
+                FROM ProductCategoryProduct
+                WHERE ProductCategory.Name = 'Bread'
+            )
+            LIMIT 2
+        ];
+    }
+}

--- a/force-app/main/default/classes/DessertProductController.cls-meta.xml
+++ b/force-app/main/default/classes/DessertProductController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/dessertCompareButton/dessertCompareButton.html
+++ b/force-app/main/default/lwc/dessertCompareButton/dessertCompareButton.html
@@ -1,0 +1,3 @@
+<template>
+    <lightning-button label="Compare Bread Prices" onclick={handleOpenModal}></lightning-button>
+</template>

--- a/force-app/main/default/lwc/dessertCompareButton/dessertCompareButton.js
+++ b/force-app/main/default/lwc/dessertCompareButton/dessertCompareButton.js
@@ -1,0 +1,11 @@
+import { LightningElement } from 'lwc';
+import DessertComparisonModal from 'c/dessertComparisonModal';
+
+export default class DessertCompareButton extends LightningElement {
+    handleOpenModal() {
+        DessertComparisonModal.open({
+            size: 'medium',
+            description: 'Compare bread product prices'
+        });
+    }
+}

--- a/force-app/main/default/lwc/dessertCompareButton/dessertCompareButton.js-meta.xml
+++ b/force-app/main/default/lwc/dessertCompareButton/dessertCompareButton.js-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__RecordPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/dessertComparisonModal/dessertComparisonModal.html
+++ b/force-app/main/default/lwc/dessertComparisonModal/dessertComparisonModal.html
@@ -1,0 +1,34 @@
+<template>
+    <lightning-modal-header label="Bread Price Comparison"></lightning-modal-header>
+    <lightning-modal-body>
+        <template if:true={products}>
+            <table class="slds-table slds-table_cell-buffer slds-table_bordered">
+                <thead>
+                    <tr>
+                        <th>Product Name</th>
+                        <th>Product Category</th>
+                        <th>Price</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <template for:each={products} for:item="product">
+                        <tr key={product.id}>
+                            <td>{product.name}</td>
+                            <td>{product.categoryName}</td>
+                            <td>{product.price}</td>
+                        </tr>
+                    </template>
+                </tbody>
+            </table>
+            <template if:true={priceDifference}>
+                <p>Price difference: {priceDifference}</p>
+            </template>
+        </template>
+        <template if:true={error}>
+            <p>{error}</p>
+        </template>
+    </lightning-modal-body>
+    <lightning-modal-footer>
+        <lightning-button label="Close" onclick={handleClose}></lightning-button>
+    </lightning-modal-footer>
+</template>

--- a/force-app/main/default/lwc/dessertComparisonModal/dessertComparisonModal.js
+++ b/force-app/main/default/lwc/dessertComparisonModal/dessertComparisonModal.js
@@ -1,0 +1,33 @@
+import LightningModal from 'lightning/modal';
+import getDessertProducts from '@salesforce/apex/DessertProductController.getDessertProducts';
+
+export default class DessertComparisonModal extends LightningModal {
+    products;
+    error;
+
+    connectedCallback() {
+        getDessertProducts()
+            .then((result) => {
+                this.products = result.map((pb) => ({
+                    id: pb.Id,
+                    name: pb.Product2?.Name,
+                    categoryName: 'Bread',
+                    price: pb.UnitPrice
+                }));
+            })
+            .catch((error) => {
+                this.error = error;
+            });
+    }
+
+    get priceDifference() {
+        if (this.products && this.products.length === 2) {
+            return Math.abs(this.products[0].price - this.products[1].price);
+        }
+        return null;
+    }
+
+    handleClose() {
+        this.close();
+    }
+}

--- a/force-app/main/default/lwc/dessertComparisonModal/dessertComparisonModal.js-meta.xml
+++ b/force-app/main/default/lwc/dessertComparisonModal/dessertComparisonModal.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary
- Fetch Bread category products with standard prices using ProductCategoryProduct join
- Show Bread product names and prices in comparison modal with updated labels

## Testing
- `npm test` (fails: sfdx-lwc-jest: not found)
- `npm run lint` (fails: Cannot find module 'eslint/config')

------
https://chatgpt.com/codex/tasks/task_e_68ad4583ce948330a77a8212024d69af